### PR TITLE
Add method isConnected to TelegramCore, update TelegramCore::timeEven…

### DIFF
--- a/embeds/telegramcore.cpp
+++ b/embeds/telegramcore.cpp
@@ -42,10 +42,17 @@ qint64 TelegramCore::retry(qint64 mid)
     return result;
 }
 
+bool TelegramCore::isConnected() const {
+    if (mApi && mApi->mainSession()) {
+        return mApi->mainSession()->state() == QAbstractSocket::ConnectedState;
+    }
+    return false;
+}
+
 void TelegramCore::timerEvent(QTimerEvent *e)
 {
     const qint64 msgId = mTimer.key(e->timerId());
-    if(msgId)
+    if(msgId && isConnected())
     {
         mTimer.remove(msgId);
         killTimer(e->timerId());

--- a/embeds/telegramcore.h
+++ b/embeds/telegramcore.h
@@ -49,6 +49,7 @@ public:
     }
 
     virtual void init() = 0;
+    bool isConnected() const;
 
 /*! === methods === !*/
 


### PR DESCRIPTION
When client was not connected to the network, the `timeEvent` method did not fail in anyway when trying to re-send query. Instead the new message with `msgId = -1` was added to the pending queries map. 

Note: Possibly there is a bug in `Session::encryptSendMessage`. -1 is returned as a result when writing to the `QAbstractSocket ` fails (can happen when internet connection is broken). This result is then used as `msgId`. The calling function to the `sendQuery` method only checks if msgId is other than 0. Problem then occurs if there are more then 1 queries with `msgId = -1`.
Also when resendQueries option is set to true , sent `TL_MsgContainer` message is rejected by telegram due to -1 msgId.

example :
 ```
qint64 msgId = mApi->messagesSendMessage(...)
    if(msgId) {
         callBackPush<UpdatesType >(msgId, callBack);    // Could already contain key with msgId = -1
         ....
```