### PR TITLE
Add class TelegramCore::CallbackStore

### DIFF
--- a/embeds/telegramcore.cpp
+++ b/embeds/telegramcore.cpp
@@ -65,13 +65,6 @@ void TelegramCore::timerEvent(QTimerEvent *e)
 
 TelegramCore::~TelegramCore()
 {
-    QHashIterator<qint64, void*> i(mCallbacks);
-    while(i.hasNext())
-    {
-        i.next();
-        Callback<int> *ptr = reinterpret_cast<Callback<int>*>(i.value());
-        delete ptr;
-    }
     mCallbacks.clear();
 }
 

--- a/embeds/telegramcore.h
+++ b/embeds/telegramcore.h
@@ -8,7 +8,11 @@
 #include <QObject>
 #include <QPointer>
 #include <QTimerEvent>
+
 #include <functional>
+#include <memory>
+#include <typeinfo>
+#include <utility>
 
 #include "telegramapi.h"
 #include "telegramcore_globals.h"
@@ -82,35 +86,91 @@ protected:
     template<typename T>
     void callBackPush(qint64 msgId, Callback<T> callback) {
         if(!callback || mCallbacks.contains(msgId)) return;
-        void *ptr = new Callback<T>(callback);
-        mCallbacks[msgId] = ptr;
+        mCallbacks.insert(msgId, CallbackStore(std::move(callback)));
     }
 
     template<typename T>
     Callback<T> callBackGet(qint64 msgId) {
-        void *ptr = mCallbacks.value(msgId);
-        if(!ptr) return 0;
-        Callback<T> *callBack = reinterpret_cast<Callback<T>*>(ptr);
-        return (*callBack);
+        return mCallbacks.value(msgId).getCallback<T>();
     }
 
     template<typename T>
     void callBackCall(qint64 msgId, const T &result, const CallbackError &error = CallbackError()) {
-        Callback<T> callBack = callBackGet<T>(msgId);
-        void *ptr = mCallbacks.take(msgId);
-        if(!ptr) return;
-        callBack(msgId, result, error);
-        delete reinterpret_cast<Callback<T>*>(ptr);
+        auto cbs = mCallbacks.take(msgId);
+        cbs(msgId, result, error);
     }
 
 private:
-    QHash<qint64, void*> mCallbacks;
+    class CallbackStore;
+    QHash<qint64, CallbackStore> mCallbacks;
     QHash<qint64, QVariantHash> mRecallArgs;
     QVariantHash mLastArgs;
     QHash<qint64, qint32> mTimer;
     static qint32 mTimeOut;
 
     /*! === privates === !*/
+};
+
+
+class TelegramCore::CallbackStore : public QObject
+{
+    Q_OBJECT
+public:
+    template<class T>
+    CallbackStore(Callback<T> func) : m_argResType(&typeid(T)) {
+        if (!func) return;
+        m_ptrCb = std::shared_ptr<void>(reinterpret_cast<void*>(new Callback<T>(std::forward<Callback<T>>(func))), [](void* p) {
+            if(p) delete reinterpret_cast<Callback<T>*>(p);
+            p = nullptr;
+        });
+    }
+
+    CallbackStore() : m_argResType(nullptr) {}
+    CallbackStore(const CallbackStore& rhs) : m_argResType(rhs.m_argResType), m_ptrCb(rhs.m_ptrCb) {}
+    CallbackStore(CallbackStore&& rhs) noexcept : m_argResType(std::move(rhs.m_argResType)), m_ptrCb(std::move(rhs.m_ptrCb)) {}
+    CallbackStore& operator=(const CallbackStore& rhs) {
+        if(&rhs != this) {
+            m_argResType = rhs.m_argResType;
+            m_ptrCb = rhs.m_ptrCb;
+        }
+        return *this;
+    }
+
+    CallbackStore& operator=(CallbackStore&& rhs) noexcept {
+        if(&rhs != this) {
+            m_argResType = std::move(rhs.m_argResType);
+            m_ptrCb = std::move(rhs.m_ptrCb);
+        }
+        return *this;
+    }
+
+    template<typename T>
+    void operator()(qint64 msgId, T&& result, const CallbackError& error) const {
+        if (*this && typeid(T) == (*m_argResType)) {
+            auto cb = reinterpret_cast<Callback<T>*>(m_ptrCb.get());
+            if (!cb || !bool(*cb)) return;
+            (*cb)(msgId, std::forward<T>(result), error);
+        }
+    }
+
+    template<typename T>
+    Callback<T> getCallback() const {
+        if(!bool(*this) || typeid(T) != (*m_argResType)) return 0;
+        QPointer<const CallbackStore> guard(this);
+        return [guard] (qint64 msgId, T&& result, const CallbackError& error) {
+             if(guard) {
+                 guard->operator()(msgId, std::forward<T>(result), error);
+             }
+        };
+    }
+
+    explicit operator bool() const {
+        return bool(m_ptrCb);
+    }
+
+private:
+    const std::type_info* m_argResType;
+    std::shared_ptr<void> m_ptrCb;
 };
 
 #endif // TELEGRAMCORE_H


### PR DESCRIPTION
CallbackStore, type safely stores callback and prevents invoking callback with wrong result type.
There was a bug in telegram.cpp L:1059 ( _onAuthLogOutAnswer(id, false, attachedData);_), when invoking non-boolean result type callback with _false_ value. It resulted in exception and crashing the app. One instance of this case was when client's session was revoked and receiving update type _updatesTooLong_. Calling tg api method _updates.getDifference_ resulted in error AUTH_KEY_INVALID and callback connected to method _getDifference_ was invoked with boolean result type instead of _UpdatesDifference_.